### PR TITLE
Redirect stderr/out to syslog

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,6 +72,8 @@ consul_systemd_restart: on-failure
 consul_systemd_restart_sec: 10s
 consul_systemd_timeout_stop_sec: 5
 consul_systemd_limit_no_file: 65536
+consul_systemd_stdout: syslog
+consul_systemd_stderr: syslog
 
 # Daemon options to be passed through consul options file
 # (/etc/default/consul or /etc/sysconfig/consul)

--- a/templates/etc/systemd/system/consul.service.j2
+++ b/templates/etc/systemd/system/consul.service.j2
@@ -3,6 +3,8 @@ Description="HashiCorp Consul - A service mesh solution"
 Documentation=https://www.consul.io/
 Requires=network-online.target
 After=network-online.target
+StandardOutput=syslog
+StandardError=syslog
 
 [Service]
 Type={{ consul_systemd_type }}

--- a/templates/etc/systemd/system/consul.service.j2
+++ b/templates/etc/systemd/system/consul.service.j2
@@ -3,8 +3,8 @@ Description="HashiCorp Consul - A service mesh solution"
 Documentation=https://www.consul.io/
 Requires=network-online.target
 After=network-online.target
-StandardOutput=syslog
-StandardError=syslog
+StandardOutput={{ consul_systemd_stdout }}
+StandardError={{ consul_systemd_stderr }}
 
 [Service]
 Type={{ consul_systemd_type }}


### PR DESCRIPTION
Usually on systemd systems there will be no rsyslog and logging
will have to go to stderr/out, so make the service redirect that
to syslog